### PR TITLE
Add .amsterdam to tlds and test

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -6,6 +6,15 @@
         "notRegistered": "/NOT FOUND/"
     }
 }, {
+    "tld": "amsterdam",
+    "description": "Amsterdam",
+    "whoisServer": "whois.nic.amsterdam",
+    "patterns": {
+        "notRegistered": "/Status: free/",
+        "waitPeriod": "/maximum number of requests per second exceeded/"
+    },
+    "waitPeriod": 1
+}, {
     "tld": "asia",
     "description": "Asia-Pacific region",
     "whoisServer": "asia.whois-servers.net",

--- a/tests/AvailabilityCheckTest.php
+++ b/tests/AvailabilityCheckTest.php
@@ -53,6 +53,7 @@ class AvailabilityCheckTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [ 'nic.aero', false ], [ 'nicabcdefgh.aero', true ],
+            [ 'nic.amsterdam', false ], [ 'nicabcdefgh.amsterdam', true ],
             [ 'nic.asia', false ], [ 'nicabcdefgh.asia', true ],
             [ 'nic.biz', false ], [ 'nicabcdefgh.biz', true ],
             [ 'nic.cat', false ], [ 'nicabcdefgh.cat', true ],


### PR DESCRIPTION
This PR adds .amsterdam to the tld.json and to the availability test.